### PR TITLE
Corrigindo bug do botão da tela inicial

### DIFF
--- a/app/templates/inicio.html
+++ b/app/templates/inicio.html
@@ -49,7 +49,7 @@
 
                 <p class="conteudo"> Quer ser o primeiro?</p>
 
-                <a href="">
+                <a href="{{ url_for('main.postar_receita') }}">
                     <button class="botao">Criar receita</button>
                 </a>
             </div>


### PR DESCRIPTION
Correção do bug do botão da tela inicial quando não há postagens, o botão não leva a lugar nenhum. Agora leva para página de criar receita.